### PR TITLE
Fix DNS rebinding in HTTP and WebSocket upstream dialing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ./mysql:/var/lib/mysql
 
   emby-proxy:
-    image: ghcr.io/gsy-allen/emby-proxy-go:v1.1
+    image: ghcr.io/gsy-allen/emby-proxy-go:v1.2
     container_name: emby-proxy
     restart: unless-stopped
     logging:

--- a/handler.go
+++ b/handler.go
@@ -39,6 +39,11 @@ type ProxyHandler struct {
 	allowUnsafeDNS bool
 }
 
+const upstreamDialTimeout = 30 * time.Second
+const upstreamKeepAlive = 60 * time.Second
+
+type resolvedTargetContextKey struct{}
+
 func parseBlockPrivateTargets(raw string) bool {
 	if raw == "" {
 		return true
@@ -56,12 +61,12 @@ func parseBlockPrivateTargets(raw string) bool {
 func NewProxyHandler(blockPrivateTargets bool) *ProxyHandler {
 	h := &ProxyHandler{resolver: net.DefaultResolver, allowUnsafeDNS: !blockPrivateTargets}
 	transport := &http.Transport{
-		MaxIdleConns:        200,
-		MaxIdleConnsPerHost: 20,
-		MaxConnsPerHost:     50,
-		IdleConnTimeout:     120 * time.Second,
-		TLSClientConfig:     &tls.Config{},
-		DialContext:         h.dialContext,
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   20,
+		MaxConnsPerHost:       50,
+		IdleConnTimeout:       120 * time.Second,
+		TLSClientConfig:       &tls.Config{},
+		DialContext:           h.dialContext,
 		TLSHandshakeTimeout:   15 * time.Second,
 		ResponseHeaderTimeout: 300 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
@@ -92,34 +97,73 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var rt *resolvedTarget
 	if !h.allowUnsafeDNS {
-		if err := validateTargetSafety(r.Context(), h.resolver, t); err != nil {
+		rt, err = resolveSafeTarget(r.Context(), h.resolver, t)
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		r = r.WithContext(context.WithValue(r.Context(), resolvedTargetContextKey{}, rt))
 	}
 
 	start := time.Now()
 	if isWebSocketRequest(r) {
-		h.serveWebSocket(w, r, t, start)
+		h.serveWebSocket(w, r, t, rt, start)
 		return
 	}
 
 	h.serveHTTPProxy(w, r, t, start)
 }
 
+func resolvedTargetFromContext(ctx context.Context) (*resolvedTarget, error) {
+	rt, ok := ctx.Value(resolvedTargetContextKey{}).(*resolvedTarget)
+	if !ok || rt == nil {
+		return nil, fmt.Errorf("missing resolved target")
+	}
+	if len(rt.dialAddrs) == 0 {
+		return nil, fmt.Errorf("missing resolved target addresses")
+	}
+	return rt, nil
+}
+
+func dialResolvedAddresses(ctx context.Context, network string, dialer *net.Dialer, addrs []string, onConn func(net.Conn) (net.Conn, error)) (net.Conn, error) {
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("missing resolved target addresses")
+	}
+	var lastErr error
+	for _, addr := range addrs {
+		conn, err := dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if onConn == nil {
+			return conn, nil
+		}
+		wrapped, err := onConn(conn)
+		if err == nil {
+			return wrapped, nil
+		}
+		conn.Close()
+		lastErr = err
+	}
+	if lastErr == nil {
+		return nil, fmt.Errorf("missing resolved target addresses")
+	}
+	return nil, lastErr
+}
+
 func (h *ProxyHandler) dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	host, _, err := net.SplitHostPort(addr)
+	dialer := &net.Dialer{Timeout: upstreamDialTimeout, KeepAlive: upstreamKeepAlive}
+	if h.allowUnsafeDNS {
+		return dialer.DialContext(ctx, network, addr)
+	}
+	rt, err := resolvedTargetFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if !h.allowUnsafeDNS {
-		if err := validateHostSafety(ctx, h.resolver, host); err != nil {
-			return nil, err
-		}
-	}
-	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 60 * time.Second}
-	return dialer.DialContext(ctx, network, addr)
+	return dialResolvedAddresses(ctx, network, dialer, rt.dialAddresses(), nil)
 }
 
 func (h *ProxyHandler) serveHTTPProxy(w http.ResponseWriter, r *http.Request, t *target, start time.Time) {
@@ -279,4 +323,3 @@ func looksLikeMedia(path string) bool {
 	}
 	return false
 }
-

--- a/handler_http_test.go
+++ b/handler_http_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newUnsafeTestProxyHandler() *ProxyHandler {
@@ -293,5 +295,88 @@ func TestServeHTTPBlocksDangerousTarget(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "blocked target host") {
 		t.Fatalf("body = %q, want blocked target host message", rr.Body.String())
+	}
+}
+
+func TestResolvedTargetFromContextRequiresAddresses(t *testing.T) {
+	_, err := resolvedTargetFromContext(context.WithValue(context.Background(), resolvedTargetContextKey{}, &resolvedTarget{}))
+	if err == nil || !strings.Contains(err.Error(), "missing resolved target addresses") {
+		t.Fatalf("resolvedTargetFromContext() error = %v, want missing resolved target addresses", err)
+	}
+}
+
+func TestDialContextUsesResolvedTargetAddress(t *testing.T) {
+	handler := NewProxyHandler(true)
+	handler.allowUnsafeDNS = false
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			accepted <- ""
+			return
+		}
+		accepted <- conn.RemoteAddr().String()
+		conn.Close()
+	}()
+
+	target := &target{Scheme: "http", Domain: "example.com", Port: ln.Addr().(*net.TCPAddr).Port}
+	rt := &resolvedTarget{dialAddrs: []string{net.JoinHostPort("127.0.0.1", strconv.Itoa(target.Port))}}
+	ctx := context.WithValue(context.Background(), resolvedTargetContextKey{}, rt)
+
+	conn, err := handler.dialContext(ctx, "tcp", net.JoinHostPort(target.Domain, strconv.Itoa(target.Port)))
+	if err != nil {
+		t.Fatalf("dialContext() error = %v", err)
+	}
+	conn.Close()
+
+	if got := <-accepted; got == "" {
+		t.Fatal("expected listener to accept resolved target connection")
+	}
+}
+
+func TestDialContextFallsBackToNextResolvedTargetAddress(t *testing.T) {
+	handler := NewProxyHandler(true)
+	handler.allowUnsafeDNS = false
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+			accepted <- struct{}{}
+		}
+	}()
+
+	resolved := &resolvedTarget{
+		dialAddrs: []string{
+			net.JoinHostPort("127.0.0.2", strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)),
+			net.JoinHostPort("127.0.0.1", strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)),
+		},
+	}
+	ctx := context.WithValue(context.Background(), resolvedTargetContextKey{}, resolved)
+
+	conn, err := handler.dialContext(ctx, "tcp", net.JoinHostPort("example.com", strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)))
+	if err != nil {
+		t.Fatalf("dialContext() fallback error = %v", err)
+	}
+	conn.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected listener to accept fallback resolved target connection")
 	}
 }

--- a/handler_ws_test.go
+++ b/handler_ws_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -435,6 +436,16 @@ func TestWebSocketProxyBlocksDangerousTarget(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestDialTargetConnRequiresResolvedTargetWhenDNSBlockingEnabled(t *testing.T) {
+	handler := NewProxyHandler(true)
+	handler.allowUnsafeDNS = false
+
+	_, err := handler.dialTargetConn(context.Background(), &target{Scheme: "http", Domain: "example.com", Port: 80}, nil)
+	if err == nil || !strings.Contains(err.Error(), "missing resolved target") {
+		t.Fatalf("dialTargetConn() error = %v, want missing resolved target", err)
 	}
 }
 

--- a/target.go
+++ b/target.go
@@ -18,6 +18,10 @@ type target struct {
 	Query  string
 }
 
+type resolvedTarget struct {
+	dialAddrs []string
+}
+
 func parseTarget(path, query string) (*target, error) {
 	trimmed := strings.TrimPrefix(path, "/")
 	if trimmed == "" {
@@ -132,28 +136,61 @@ func normalizeTargetHost(host string) string {
 	return strings.TrimSuffix(host, ".")
 }
 
-func validateTargetSafety(ctx context.Context, resolver *net.Resolver, t *target) error {
-	return validateHostSafety(ctx, resolver, t.Domain)
+func (rt *resolvedTarget) dialAddresses() []string {
+	return rt.dialAddrs
 }
 
-func validateHostSafety(ctx context.Context, resolver *net.Resolver, host string) error {
+func resolveSafeTarget(ctx context.Context, resolver *net.Resolver, t *target) (*resolvedTarget, error) {
+	ips, err := resolveSafeHostIPs(ctx, resolver, t.Domain)
+	if err != nil {
+		return nil, err
+	}
+	return &resolvedTarget{dialAddrs: buildDialAddresses(ips, t.Port)}, nil
+}
+
+func buildDialAddresses(ips []net.IP, port int) []string {
+	addrs := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		addrs = append(addrs, net.JoinHostPort(ip.String(), strconv.Itoa(port)))
+	}
+	return addrs
+}
+
+func resolveSafeHostIPs(ctx context.Context, resolver *net.Resolver, host string) ([]net.IP, error) {
 	normalized := normalizeTargetHost(host)
 	if normalized == "" {
-		return fmt.Errorf("domain is required")
+		return nil, fmt.Errorf("domain is required")
 	}
 	if normalized == "localhost" || normalized == "host.docker.internal" {
-		return fmt.Errorf("blocked target host: %s", host)
+		return nil, fmt.Errorf("blocked target host: %s", host)
 	}
 	ips, err := resolveTargetIPs(ctx, resolver, normalized)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	unsafeIPs := false
+	safeIPs := make([]net.IP, 0, len(ips))
 	for _, ip := range ips {
 		if isDangerousIP(ip) {
-			return fmt.Errorf("blocked target host: %s", host)
+			unsafeIPs = true
+			continue
 		}
+		safeIPs = append(safeIPs, ip)
 	}
-	return nil
+	if unsafeIPs || len(safeIPs) == 0 {
+		return nil, fmt.Errorf("blocked target host: %s", host)
+	}
+	return safeIPs, nil
+}
+
+func validateTargetSafety(ctx context.Context, resolver *net.Resolver, t *target) error {
+	_, err := resolveSafeTarget(ctx, resolver, t)
+	return err
+}
+
+func validateHostSafety(ctx context.Context, resolver *net.Resolver, host string) error {
+	_, err := resolveSafeHostIPs(ctx, resolver, host)
+	return err
 }
 
 func resolveTargetIPs(ctx context.Context, resolver *net.Resolver, host string) ([]net.IP, error) {

--- a/target_test.go
+++ b/target_test.go
@@ -221,11 +221,28 @@ func TestValidateTargetSafety(t *testing.T) {
 	}
 }
 
+func TestResolveSafeTarget(t *testing.T) {
+	ctx := context.Background()
+	target := &target{Scheme: "https", Domain: "8.8.8.8", Port: 443}
+
+	rt, err := resolveSafeTarget(ctx, net.DefaultResolver, target)
+	if err != nil {
+		t.Fatalf("resolveSafeTarget(%q) unexpected error: %v", target.Domain, err)
+	}
+	addrs := rt.dialAddresses()
+	if len(addrs) != 1 {
+		t.Fatalf("resolved address count = %d, want 1", len(addrs))
+	}
+	if addrs[0] != "8.8.8.8:443" {
+		t.Fatalf("dialAddresses()[0] = %q, want %q", addrs[0], "8.8.8.8:443")
+	}
+}
+
 func TestParseBlockPrivateTargets(t *testing.T) {
 	tests := []struct {
-		name  string
-		raw   string
-		want  bool
+		name string
+		raw  string
+		want bool
 	}{
 		{name: "default empty true", raw: "", want: true},
 		{name: "explicit true", raw: "true", want: true},

--- a/websocket.go
+++ b/websocket.go
@@ -19,7 +19,7 @@ import (
 
 const webSocketHandshakeTimeout = 10 * time.Second
 
-func (h *ProxyHandler) serveWebSocket(w http.ResponseWriter, r *http.Request, t *target, start time.Time) {
+func (h *ProxyHandler) serveWebSocket(w http.ResponseWriter, r *http.Request, t *target, rt *resolvedTarget, start time.Time) {
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "websocket not supported", http.StatusInternalServerError)
@@ -35,7 +35,7 @@ func (h *ProxyHandler) serveWebSocket(w http.ResponseWriter, r *http.Request, t 
 	defer clientConn.Close()
 	_ = clientConn.SetDeadline(time.Now().Add(webSocketHandshakeTimeout))
 
-	upstreamConn, err := h.dialTargetConn(r.Context(), t)
+	upstreamConn, err := h.dialTargetConn(r.Context(), t, rt)
 	if err != nil {
 		log.Printf("[ERROR] websocket dial %s/%s failed: %v", t.Domain, t.Path, err)
 		writeHijackedHTTPError(clientRW, http.StatusBadGateway, "upstream websocket connection failed")
@@ -116,18 +116,27 @@ func isWebSocketRequest(r *http.Request) bool {
 	return headerContainsToken(r.Header, "Connection", "upgrade") && strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket")
 }
 
-func (h *ProxyHandler) dialTargetConn(ctx context.Context, t *target) (net.Conn, error) {
+func (h *ProxyHandler) dialTargetConn(ctx context.Context, t *target, rt *resolvedTarget) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: upstreamDialTimeout, KeepAlive: upstreamKeepAlive}
+	addrs := []string{net.JoinHostPort(t.Domain, strconv.Itoa(t.Port))}
 	if !h.allowUnsafeDNS {
-		if err := validateTargetSafety(ctx, h.resolver, t); err != nil {
+		if rt == nil {
+			return nil, fmt.Errorf("missing resolved target")
+		}
+		addrs = rt.dialAddresses()
+	}
+	return dialResolvedAddresses(ctx, "tcp", dialer, addrs, func(conn net.Conn) (net.Conn, error) {
+		if t.Scheme != "https" {
+			return conn, nil
+		}
+		_ = conn.SetDeadline(time.Now().Add(webSocketHandshakeTimeout))
+		tlsConn := tls.Client(conn, &tls.Config{ServerName: t.Domain})
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
 			return nil, err
 		}
-	}
-	addr := net.JoinHostPort(t.Domain, strconv.Itoa(t.Port))
-	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 60 * time.Second}
-	if t.Scheme == "https" {
-		return tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{ServerName: t.Domain})
-	}
-	return dialer.DialContext(ctx, "tcp", addr)
+		_ = tlsConn.SetDeadline(time.Time{})
+		return tlsConn, nil
+	})
 }
 
 func writeWebSocketRequest(conn net.Conn, r *http.Request, t *target) error {


### PR DESCRIPTION
## Summary
  - bind upstream connections to the IPs resolved during safety validation instead of re-resolving hostnames at dial time
  - apply the same safe dialing model to both HTTP and WebSocket/WSS paths
  - support fallback across multiple validated public IPs from a single DNS resolution result while preserving the original hostname for Host/SNI

  ## Why
  The proxy previously validated target DNS results before forwarding, but the actual upstream connection could still trigger a separate hostname resolution later. That created a DNS rebinding window where the validated address and the connected address could differ.

  This change closes that gap by resolving once, validating once, and dialing only the validated addresses.

  ## Implementation details
  - add a resolved target model that stores prevalidated dial addresses
  - resolve and validate target addresses at request entry when private/dangerous targets are blocked
  - reuse the validated dial addresses in:
    - HTTP transport dialing
    - WebSocket upstream dialing
    - WSS/TLS upstream dialing
  - keep the original domain for request Host handling and TLS `ServerName`
  - add fallback across multiple validated public IPs from the same resolution result (important for proxied/CDN hosts such as Cloudflare)

  ## Test plan
  - [x] run `go test ./...`
  - [x] verify HTTP dialing uses validated resolved addresses
  - [x] verify dialing falls back to the next validated address when the first one fails
  - [x] verify WebSocket dialing requires a validated resolved target when DNS safety blocking is enabled
  - [x] manually test normal proxy behavior after the change