### PR TITLE
fix UHD emby playing in forword and upgrade to 1.2.3

### DIFF
--- a/README-b.md
+++ b/README-b.md
@@ -90,7 +90,7 @@ services:
       - emby-proxy
 
   emby-proxy:
-    image: ghcr.io/gsy-allen/emby-proxy-go:v1.2.2
+    image: ghcr.io/gsy-allen/emby-proxy-go:v1.2.3
     container_name: emby-proxy
     restart: unless-stopped
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ./mysql:/var/lib/mysql
 
   emby-proxy:
-    image: ghcr.io/gsy-allen/emby-proxy-go:v1.2.2
+    image: ghcr.io/gsy-allen/emby-proxy-go:v1.2.3
     container_name: emby-proxy
     restart: unless-stopped
     logging:

--- a/handler.go
+++ b/handler.go
@@ -170,7 +170,9 @@ func (h *ProxyHandler) serveHTTPProxy(w http.ResponseWriter, r *http.Request, t 
 	baseURL := inferBaseURL(r)
 	media := looksLikeMedia(t.Path)
 
-	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, buildTargetURL(t), r.Body)
+	upstreamTarget := *t
+	upstreamTarget.Path = rewriteBarePlaybackPathForHTTP(t.Path)
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, buildTargetURL(&upstreamTarget), r.Body)
 	if err != nil {
 		http.Error(w, "failed to create request", http.StatusInternalServerError)
 		return

--- a/handler_http_test.go
+++ b/handler_http_test.go
@@ -88,6 +88,91 @@ func TestNormalizeContentEncoding(t *testing.T) {
 	}
 }
 
+func TestServeHTTPBareItemsCountsRewritesToEmbyPrefix(t *testing.T) {
+	rr, _ := serveProxyRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/emby/Items/Counts" {
+			t.Fatalf("path = %q, want %q", got, "/emby/Items/Counts")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"MovieCount":1}`))
+	}, "/Items/Counts")
+
+	assertResponseStatus(t, rr, http.StatusOK)
+}
+
+func TestServeHTTPBareServerDomainsRewritesToEmbyPrefix(t *testing.T) {
+	rr, _ := serveProxyRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/emby/System/Ext/ServerDomains" {
+			t.Fatalf("path = %q, want %q", got, "/emby/System/Ext/ServerDomains")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}, "/System/Ext/ServerDomains")
+
+	assertResponseStatus(t, rr, http.StatusOK)
+}
+
+func TestServeHTTPBarePlaybackInfoRewritesToEmbyPrefix(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/emby/Items/123/PlaybackInfo" {
+			t.Fatalf("path = %q, want %q", got, "/emby/Items/123/PlaybackInfo")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"MediaSources":[]}`))
+	}))
+	defer upstream.Close()
+
+	port := upstream.Listener.Addr().(*net.TCPAddr).Port
+	handler := newUnsafeTestProxyHandler()
+	req := httptest.NewRequest(http.MethodPost, "/http/127.0.0.1/"+strconv.Itoa(port)+"/Items/123/PlaybackInfo", strings.NewReader(`{}`))
+	req.Host = "proxy.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assertResponseStatus(t, rr, http.StatusOK)
+}
+
+func TestServeHTTPBareAdditionalPartsRewritesToEmbyPrefix(t *testing.T) {
+	rr, _ := serveProxyRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/emby/Videos/123/AdditionalParts" {
+			t.Fatalf("path = %q, want %q", got, "/emby/Videos/123/AdditionalParts")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}, "/Videos/123/AdditionalParts")
+
+	assertResponseStatus(t, rr, http.StatusOK)
+}
+
+func TestServeHTTPBareSimilarRewritesToEmbyPrefix(t *testing.T) {
+	rr, _ := serveProxyRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/emby/Items/123/Similar" {
+			t.Fatalf("path = %q, want %q", got, "/emby/Items/123/Similar")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Items":[]}`))
+	}, "/Items/123/Similar")
+
+	assertResponseStatus(t, rr, http.StatusOK)
+}
+
+func TestServeHTTPBareMediaPathStaysUnchanged(t *testing.T) {
+	rr, _ := serveProxyRequest(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/Videos/123/original.mkv" {
+			t.Fatalf("path = %q, want %q", got, "/Videos/123/original.mkv")
+		}
+		w.Header().Set("Content-Type", "video/mp4")
+		_, _ = w.Write([]byte("ok"))
+	}, "/Videos/123/original.mkv")
+
+	assertResponseStatus(t, rr, http.StatusOK)
+}
+
 func TestServeHTTPBadTarget(t *testing.T) {
 	handler := newUnsafeTestProxyHandler()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/target.go
+++ b/target.go
@@ -67,6 +67,46 @@ func buildTargetURL(t *target) string {
 	return b.String()
 }
 
+func rewriteBarePlaybackPathForHTTP(path string) string {
+	if path == "" || hasPathPrefixFold(path, "emby/") {
+		return path
+	}
+	if hasPathExactFold(path, "Items/Counts") {
+		return "emby/" + path
+	}
+	if hasPathExactFold(path, "System/Ext/ServerDomains") {
+		return "emby/" + path
+	}
+	if hasPathSuffixFold(path, "/PlaybackInfo") && hasPathPrefixFold(path, "Items/") {
+		return "emby/" + path
+	}
+	if hasPathSuffixFold(path, "/Similar") && hasPathPrefixFold(path, "Items/") {
+		return "emby/" + path
+	}
+	if hasPathSuffixFold(path, "/AdditionalParts") && hasPathPrefixFold(path, "Videos/") {
+		return "emby/" + path
+	}
+	return path
+}
+
+func hasPathExactFold(path, want string) bool {
+	return strings.EqualFold(path, want)
+}
+
+func hasPathPrefixFold(path, prefix string) bool {
+	if len(path) < len(prefix) {
+		return false
+	}
+	return strings.EqualFold(path[:len(prefix)], prefix)
+}
+
+func hasPathSuffixFold(path, suffix string) bool {
+	if len(path) < len(suffix) {
+		return false
+	}
+	return strings.EqualFold(path[len(path)-len(suffix):], suffix)
+}
+
 func trimIPv6LiteralBrackets(host string) string {
 	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
 		inner := host[1 : len(host)-1]

--- a/target_test.go
+++ b/target_test.go
@@ -226,6 +226,32 @@ func TestBuildTargetURL(t *testing.T) {
 	}
 }
 
+func TestRewriteBarePlaybackPathForHTTP(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "rewrite bare items counts", path: "Items/Counts", want: "emby/Items/Counts"},
+		{name: "rewrite bare server domains", path: "System/Ext/ServerDomains", want: "emby/System/Ext/ServerDomains"},
+		{name: "rewrite bare playback info", path: "Items/123/PlaybackInfo", want: "emby/Items/123/PlaybackInfo"},
+		{name: "rewrite bare similar", path: "Items/123/Similar", want: "emby/Items/123/Similar"},
+		{name: "rewrite bare additional parts", path: "Videos/123/AdditionalParts", want: "emby/Videos/123/AdditionalParts"},
+		{name: "already prefixed stays same", path: "emby/Items/123/PlaybackInfo", want: "emby/Items/123/PlaybackInfo"},
+		{name: "normal media path stays same", path: "Videos/123/original.mkv", want: "Videos/123/original.mkv"},
+		{name: "bare users items stays same", path: "Users/123/Items", want: "Users/123/Items"},
+		{name: "system ping stays same", path: "System/Ping", want: "System/Ping"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rewriteBarePlaybackPathForHTTP(tt.path); got != tt.want {
+				t.Fatalf("rewriteBarePlaybackPathForHTTP(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTargetHostPort(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
反代后UHD emby在senplayer正常播放，但是在forward上无法正常播放，也无法获取正常的剧集统计值。打了一些log发现这是由于
/Items/Counts
/System/Ext/ServerDomains
/Items/{id}/Similar
/Items/{id}/PlaybackInfo
/Videos/{id}/AdditionalParts
这几个接口返回404，与senplayer的日志进行比较，发现没有携带/emby，
/emby/Items/Counts
/emby/System/Ext/ServerDomains
/emby/Items/{id}/Similar
/emby/Items/{id}/PlaybackInfo
/emby/Videos/{id}/AdditionalParts
对此进行补充，如果没有，则增加/emby。
理论上应该是UHD emby后端接口进行兼容，普通emby服没有该值也能正常播放，但顺便先提交一个fix进行使用